### PR TITLE
Test when a guest user create a book_suggestion

### DIFF
--- a/spec/controllers/book_suggestion_controller_spec.rb
+++ b/spec/controllers/book_suggestion_controller_spec.rb
@@ -101,5 +101,22 @@ RSpec.describe BookSuggestionController, type: :controller do
         expect(response).to have_http_status(:unprocessable_entity)
       end
     end
+
+    context 'When the user is guest' do
+      let!(:book_suggestion) { build(:book_suggestion, user: nil) }
+
+      before do
+        post :create, params: params
+      end
+
+      it 'responds with the book suggestion json' do
+        expected = book_suggestion.to_json
+        expect(response.body.to_json) =~ JSON.parse(expected)
+      end
+
+      it 'responds with 201 status' do
+        expect(response).to have_http_status(:created)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

Test for book_suggestion create (When is a guest user)

- Add the context 'When the user is guest'
- Check the response for status created
- Test to respond the book_suggestion json

## Screenshots

## TRELLO Card

https://trello.com/c/5GPCRMBp/31-crear-test-para-endpoint-de-creaci%C3%B3n-de-un-booksuggestion